### PR TITLE
Integrate registerUser – Connect Ethereum to Starknet pubkey

### DIFF
--- a/app/dapp/claim-burn/page.tsx
+++ b/app/dapp/claim-burn/page.tsx
@@ -2,6 +2,9 @@
 
 import { useWallet } from '@/app/hooks/useWallet';
 import { useEffect, useMemo, useState } from 'react';
+import { ethers } from 'ethers';
+import bridgeAbi from '@/lib/bridgeAbi.json';
+import { useTranslation } from 'react-i18next';
 import { SuccessModal } from './components/success';
 import { ConnectWalletButton } from '../components/ui/ConnectWalletButton';
 import Image from 'next/image';
@@ -30,12 +33,16 @@ type BurnClaimData = {
 
 export default function ClaimBurnPage() {
   const { isDark } = useThemeContext();
-  const { isConnected, openWalletModal } = useWallet();
+  const wallet = useWallet();
+  const { t } = useTranslation ? useTranslation() : { t: (x: string) => x };
   const [activeTab, setActiveTab] = useState('claim');
   const [amount, setAmount] = useState('');
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [registering, setRegistering] = useState(false);
+  const [registerStatus, setRegisterStatus] = useState<string | null>(null);
 
+  const isConnected = wallet?.isConnected;
   const CLAIM_BURN_DATA: Record<string, BurnClaimData> = useMemo(
     () => ({
       claim: {
@@ -55,6 +62,32 @@ export default function ClaimBurnPage() {
     }),
     [isConnected]
   );
+
+  // Register Starknet Key logic
+  const handleRegisterStarknetKey = async () => {
+    setRegisterStatus(null);
+    setRegistering(true);
+    try {
+      const ethAddress = wallet.ethAddress;
+      const strkAddress = wallet.strkAddress;
+      if (!ethAddress || !strkAddress) throw new Error("Connect both wallets first.");
+
+      const message = `Register Starknet pubkey: ${strkAddress}`;
+      const provider = new ethers.BrowserProvider(window.ethereum);
+      const signer = await provider.getSigner();
+      const signature = await signer.signMessage(message);
+
+      const contract = new ethers.Contract("0x8F25bFe32269632dfd8D223D51FF145414d8107b", bridgeAbi, signer);
+      const starknetPubKey = ethers.toBigInt(strkAddress);
+      const tx = await contract.registerUser(signature, starknetPubKey);
+      await tx.wait();
+      setRegisterStatus("Registration successful!");
+    } catch (err: any) {
+      setRegisterStatus(err.message || "Registration failed");
+    } finally {
+      setRegistering(false);
+    }
+  };
 
   const currentData = CLAIM_BURN_DATA[activeTab];
 
@@ -235,17 +268,31 @@ export default function ClaimBurnPage() {
 
                 {!isConnected ? (
                   <ConnectWalletButton
-                    action={openWalletModal}
+                    action={wallet.openWalletModal}
                     className="w-full rounded-[12px] font-light"
                   />
                 ) : (
-                  <button
-                    onClick={handleAction}
-                    disabled={!isActionable}
-                    className={`w-full py-4 rounded-4xl font-bold text-sm transition-colors ${claimBurnBtnClasses} ${inter.className}`}
-                  >
-                    {activeTab === 'claim' ? 'Claim xZB' : 'Burn xZB'}
-                  </button>
+                  <>
+                    <button
+                      onClick={handleAction}
+                      disabled={!isActionable}
+                      className={`w-full py-4 rounded-4xl font-bold text-sm transition-colors ${claimBurnBtnClasses} ${inter.className}`}
+                    >
+                      {activeTab === 'claim' ? 'Claim xZB' : 'Burn xZB'}
+                    </button>
+                    <button
+                      onClick={handleRegisterStarknetKey}
+                      disabled={registering || !wallet.ethAddress || !wallet.strkAddress}
+                      className={`w-full mt-4 py-3 rounded-4xl font-bold text-sm transition-colors bg-blue-600 text-white hover:bg-blue-700 ${inter.className}`}
+                    >
+                      {registering ? "Registering..." : "Register Starknet Key"}
+                    </button>
+                    {registerStatus && (
+                      <div className="mt-2 text-center text-sm">
+                        {registerStatus}
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
             </div>

--- a/lib/bridgeAbi.json
+++ b/lib/bridgeAbi.json
@@ -1,0 +1,511 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_admin", "type": "address" },
+      { "internalType": "address", "name": "_initialOwner", "type": "address" },
+      { "internalType": "address", "name": "_proofRegistry", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ClaimEvent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ZeroXBridgeL1.AssetType",
+        "name": "assetType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "commitmentHash",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositEvent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "DewhitelistEvent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FundsClaimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "commitmentHash",
+        "type": "uint256"
+      }
+    ],
+    "name": "FundsUnlocked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "relayer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "status",
+        "type": "bool"
+      }
+    ],
+    "name": "RelayerStatusChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ZeroXBridgeL1.AssetType",
+        "name": "assetType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      }
+    ],
+    "name": "TokenRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "starknetPubKey",
+        "type": "uint256"
+      }
+    ],
+    "name": "UserRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "WhitelistEvent",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "approvedRelayers",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum ZeroXBridgeL1.AssetType",
+        "name": "assetType",
+        "type": "uint8"
+      },
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "depositAsset",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fetchReserveTVL",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum ZeroXBridgeL1.AssetType",
+        "name": "assetType",
+        "type": "uint8"
+      },
+      { "internalType": "address", "name": "tokenAddress", "type": "address" }
+    ],
+    "name": "getTokenData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "enum ZeroXBridgeL1.AssetType",
+            "name": "assetType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenAddress",
+            "type": "address"
+          },
+          { "internalType": "bool", "name": "isRegistered", "type": "bool" }
+        ],
+        "internalType": "struct ZeroXBridgeL1.TokenAssetData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenAddress", "type": "address" }
+    ],
+    "name": "getTokenPriceUSD",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "nextDepositNonce",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "priceFeeds",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proofRegistry",
+    "outputs": [
+      {
+        "internalType": "contract IProofRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum ZeroXBridgeL1.AssetType",
+        "name": "assetType",
+        "type": "uint8"
+      },
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "address", "name": "priceFeed", "type": "address" },
+      { "internalType": "uint8", "name": "decimals", "type": "uint8" }
+    ],
+    "name": "registerToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes", "name": "signature", "type": "bytes" },
+      { "internalType": "uint256", "name": "starknetPubKey", "type": "uint256" }
+    ],
+    "name": "registerUser",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "relayer", "type": "address" },
+      { "internalType": "bool", "name": "status", "type": "bool" }
+    ],
+    "name": "setRelayerStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "starkPubKeyRecord",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "supportedTokens",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "tokenDecimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "tokenRegistry",
+    "outputs": [
+      {
+        "internalType": "enum ZeroXBridgeL1.AssetType",
+        "name": "assetType",
+        "type": "uint8"
+      },
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "bool", "name": "isRegistered", "type": "bool" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tvl",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum ZeroXBridgeL1.AssetType",
+        "name": "assetType",
+        "type": "uint8"
+      },
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256[]", "name": "proofdata", "type": "uint256[]" },
+      {
+        "internalType": "uint256",
+        "name": "commitmentHash",
+        "type": "uint256"
+      },
+      { "internalType": "bytes", "name": "starknetSig", "type": "bytes" }
+    ],
+    "name": "unlockFundsWithProof",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "updateTvl",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "userDeposits",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "userRecord",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "verifiedProofs",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "messageHash", "type": "uint256" },
+      { "internalType": "bytes", "name": "starknetSig", "type": "bytes" },
+      { "internalType": "uint256", "name": "starkPubKey", "type": "uint256" }
+    ],
+    "name": "verifyStarknetSignature",
+    "outputs": [{ "internalType": "bool", "name": "isValid", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
This PR wires up the UI to allow users to register their Starknet public key by signing a message with their Ethereum wallet and calling the registerUser(signature, starknetPubKey) function on the L1 Bridge contract.

Key changes:

-> Added a "Register Starknet Key" button to the Claim/Burn page.
-> When both Ethereum and Starknet wallets are connected, users can sign a message with their Ethereum wallet to prove ownership.
-> The signed message and Starknet public key are sent to the L1 Bridge contract (0x8F25bFe32269632dfd8D223D51FF145414d8107b on Sepolia) via the registerUser function.
-> Success and error states are handled and displayed to the user.
-> Includes a debug info box for wallet state (remove before production if needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Register Starknet Key” flow on the Claim/Burn page, enabling on-chain registration with clear status messages.
  * Button auto-disables when prerequisites are missing or while processing to prevent errors.
* **Bug Fixes**
  * Improved wallet modal triggering for more reliable connection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->